### PR TITLE
Add custom sorting buttons API

### DIFF
--- a/src/api/java/net/blay09/mods/cookingforblockheads/api/CookingForBlockheadsAPI.java
+++ b/src/api/java/net/blay09/mods/cookingforblockheads/api/CookingForBlockheadsAPI.java
@@ -65,4 +65,8 @@ public class CookingForBlockheadsAPI {
     public static List<IKitchenItemProvider> getItemProviders(World world, BlockPos pos, InventoryPlayer player) {
         return internalMethods.getItemProviders(world, pos, player);
     }
+
+    public static void addCustomSortButton(ICustomSortButton button) {
+        internalMethods.addCustomSortButton(button);
+    }
 }

--- a/src/api/java/net/blay09/mods/cookingforblockheads/api/FoodRecipeWithStatus.java
+++ b/src/api/java/net/blay09/mods/cookingforblockheads/api/FoodRecipeWithStatus.java
@@ -1,4 +1,4 @@
-package net.blay09.mods.cookingforblockheads.registry;
+package net.blay09.mods.cookingforblockheads.api;
 
 import io.netty.buffer.ByteBuf;
 import net.minecraft.item.ItemStack;

--- a/src/api/java/net/blay09/mods/cookingforblockheads/api/ICustomSortButton.java
+++ b/src/api/java/net/blay09/mods/cookingforblockheads/api/ICustomSortButton.java
@@ -1,0 +1,15 @@
+package net.blay09.mods.cookingforblockheads.api;
+
+import java.util.Comparator;
+
+import net.minecraft.util.ResourceLocation;
+
+public interface ICustomSortButton {
+
+	ResourceLocation getIcon();
+	String getTooltip();
+	Comparator<FoodRecipeWithStatus> getComparator();
+	int getIconTextureX();
+	int getIconTextureY();
+	
+}

--- a/src/api/java/net/blay09/mods/cookingforblockheads/api/IInternalMethods.java
+++ b/src/api/java/net/blay09/mods/cookingforblockheads/api/IInternalMethods.java
@@ -1,11 +1,13 @@
 package net.blay09.mods.cookingforblockheads.api;
 
+import java.util.Comparator;
 import java.util.List;
 
 import net.blay09.mods.cookingforblockheads.api.capability.IKitchenItemProvider;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -20,5 +22,6 @@ public interface IInternalMethods {
     void addMilkItem(ItemStack milkItem);
     void addCowClass(Class<? extends EntityLivingBase> clazz);
 	List<IKitchenItemProvider> getItemProviders(World world, BlockPos pos, InventoryPlayer player);
+	void addCustomSortButton(ICustomSortButton button);
 
 }

--- a/src/api/java/net/blay09/mods/cookingforblockheads/api/RecipeStatus.java
+++ b/src/api/java/net/blay09/mods/cookingforblockheads/api/RecipeStatus.java
@@ -1,4 +1,4 @@
-package net.blay09.mods.cookingforblockheads.registry;
+package net.blay09.mods.cookingforblockheads.api;
 
 public enum RecipeStatus {
 	MISSING_INGREDIENTS,

--- a/src/main/java/net/blay09/mods/cookingforblockheads/InternalMethods.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/InternalMethods.java
@@ -2,6 +2,7 @@ package net.blay09.mods.cookingforblockheads;
 
 import java.util.List;
 
+import net.blay09.mods.cookingforblockheads.api.ICustomSortButton;
 import net.blay09.mods.cookingforblockheads.api.IInternalMethods;
 import net.blay09.mods.cookingforblockheads.api.SinkHandler;
 import net.blay09.mods.cookingforblockheads.api.ToastHandler;
@@ -59,4 +60,9 @@ public class InternalMethods implements IInternalMethods {
     public List<IKitchenItemProvider> getItemProviders(World world, BlockPos pos, InventoryPlayer player) {
         return CookingRegistry.getItemProviders(new KitchenMultiBlock(world, pos), player);
     }
+
+	@Override
+	public void addCustomSortButton(ICustomSortButton button) {
+		CookingRegistry.addCustomSortButton(button);
+	}
 }

--- a/src/main/java/net/blay09/mods/cookingforblockheads/client/gui/GuiButtonSortCustom.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/client/gui/GuiButtonSortCustom.java
@@ -1,0 +1,49 @@
+package net.blay09.mods.cookingforblockheads.client.gui;
+
+import java.util.Comparator;
+import java.util.List;
+
+import net.blay09.mods.cookingforblockheads.api.FoodRecipeWithStatus;
+import net.blay09.mods.cookingforblockheads.api.ICustomSortButton;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.resources.I18n;
+
+import com.google.common.collect.Lists;
+
+public class GuiButtonSortCustom extends GuiButton {
+
+    private final ICustomSortButton button;
+
+    private final List<String> tooltipLines = Lists.newArrayList();
+
+    public GuiButtonSortCustom(int buttonId, int x, int y, ICustomSortButton button) {
+        super(buttonId, x, y, 20, 20, "");
+        this.button = button;
+        this.tooltipLines.add(I18n.format(this.button.getTooltip()));
+    }
+
+    @Override
+    public void drawButton(Minecraft mc, int mouseX, int mouseY) {
+        this.hovered = mouseX >= this.xPosition && mouseY >= this.yPosition && mouseX < this.xPosition + this.width && mouseY < this.yPosition + this.height;
+
+        int texY = button.getIconTextureY();
+        if(!enabled) {
+            texY += 40;
+        } else if(hovered) {
+            texY += 20;
+        }
+        GlStateManager.color(1f, 1f, 1f, 1f);
+        mc.getTextureManager().bindTexture(this.button.getIcon());
+        drawTexturedModalRect(xPosition, yPosition, button.getIconTextureX(), texY, width, height);
+    }
+
+    public List<String> getTooltipLines() {
+        return tooltipLines;
+    }
+    
+    public Comparator<FoodRecipeWithStatus> getComparator() {
+        return button.getComparator();
+    }
+}

--- a/src/main/java/net/blay09/mods/cookingforblockheads/container/ContainerRecipeBook.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/container/ContainerRecipeBook.java
@@ -2,7 +2,10 @@ package net.blay09.mods.cookingforblockheads.container;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
 import net.blay09.mods.cookingforblockheads.KitchenMultiBlock;
+import net.blay09.mods.cookingforblockheads.api.FoodRecipeWithStatus;
+import net.blay09.mods.cookingforblockheads.api.RecipeStatus;
 import net.blay09.mods.cookingforblockheads.api.capability.IKitchenItemProvider;
 import net.blay09.mods.cookingforblockheads.container.comparator.ComparatorName;
 import net.blay09.mods.cookingforblockheads.container.inventory.InventoryCraftBook;
@@ -15,8 +18,6 @@ import net.blay09.mods.cookingforblockheads.network.message.MessageRecipes;
 import net.blay09.mods.cookingforblockheads.network.message.MessageRequestRecipes;
 import net.blay09.mods.cookingforblockheads.registry.CookingRegistry;
 import net.blay09.mods.cookingforblockheads.registry.FoodRecipeWithIngredients;
-import net.blay09.mods.cookingforblockheads.registry.FoodRecipeWithStatus;
-import net.blay09.mods.cookingforblockheads.registry.RecipeStatus;
 import net.blay09.mods.cookingforblockheads.registry.RecipeType;
 import net.blay09.mods.cookingforblockheads.registry.recipe.FoodIngredient;
 import net.blay09.mods.cookingforblockheads.registry.recipe.FoodRecipe;
@@ -32,6 +33,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nullable;
+
 import java.util.*;
 
 public class ContainerRecipeBook extends Container {

--- a/src/main/java/net/blay09/mods/cookingforblockheads/container/comparator/ComparatorHunger.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/container/comparator/ComparatorHunger.java
@@ -1,7 +1,7 @@
 package net.blay09.mods.cookingforblockheads.container.comparator;
 
 import net.blay09.mods.cookingforblockheads.api.CookingForBlockheadsAPI;
-import net.blay09.mods.cookingforblockheads.registry.FoodRecipeWithStatus;
+import net.blay09.mods.cookingforblockheads.api.FoodRecipeWithStatus;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemFood;
 

--- a/src/main/java/net/blay09/mods/cookingforblockheads/container/comparator/ComparatorName.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/container/comparator/ComparatorName.java
@@ -1,6 +1,6 @@
 package net.blay09.mods.cookingforblockheads.container.comparator;
 
-import net.blay09.mods.cookingforblockheads.registry.FoodRecipeWithStatus;
+import net.blay09.mods.cookingforblockheads.api.FoodRecipeWithStatus;
 
 import java.util.Comparator;
 

--- a/src/main/java/net/blay09/mods/cookingforblockheads/container/comparator/ComparatorSaturation.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/container/comparator/ComparatorSaturation.java
@@ -1,7 +1,7 @@
 package net.blay09.mods.cookingforblockheads.container.comparator;
 
 import net.blay09.mods.cookingforblockheads.api.CookingForBlockheadsAPI;
-import net.blay09.mods.cookingforblockheads.registry.FoodRecipeWithStatus;
+import net.blay09.mods.cookingforblockheads.api.FoodRecipeWithStatus;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemFood;
 

--- a/src/main/java/net/blay09/mods/cookingforblockheads/container/slot/FakeSlotRecipe.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/container/slot/FakeSlotRecipe.java
@@ -1,6 +1,6 @@
 package net.blay09.mods.cookingforblockheads.container.slot;
 
-import net.blay09.mods.cookingforblockheads.registry.FoodRecipeWithStatus;
+import net.blay09.mods.cookingforblockheads.api.FoodRecipeWithStatus;
 import net.minecraft.item.ItemStack;
 
 public class FakeSlotRecipe extends FakeSlot {

--- a/src/main/java/net/blay09/mods/cookingforblockheads/network/message/MessageItemList.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/network/message/MessageItemList.java
@@ -1,8 +1,9 @@
 package net.blay09.mods.cookingforblockheads.network.message;
 
 import com.google.common.collect.Lists;
+
 import io.netty.buffer.ByteBuf;
-import net.blay09.mods.cookingforblockheads.registry.FoodRecipeWithStatus;
+import net.blay09.mods.cookingforblockheads.api.FoodRecipeWithStatus;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 
 import java.util.Collection;

--- a/src/main/java/net/blay09/mods/cookingforblockheads/registry/CookingRegistry.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/registry/CookingRegistry.java
@@ -1,28 +1,38 @@
 package net.blay09.mods.cookingforblockheads.registry;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
 import net.blay09.mods.cookingforblockheads.KitchenMultiBlock;
-import net.blay09.mods.cookingforblockheads.compat.HarvestCraftAddon;
+import net.blay09.mods.cookingforblockheads.api.ICustomSortButton;
+import net.blay09.mods.cookingforblockheads.api.RecipeStatus;
 import net.blay09.mods.cookingforblockheads.api.SinkHandler;
 import net.blay09.mods.cookingforblockheads.api.ToastHandler;
 import net.blay09.mods.cookingforblockheads.api.capability.IKitchenItemProvider;
 import net.blay09.mods.cookingforblockheads.api.capability.KitchenItemProvider;
 import net.blay09.mods.cookingforblockheads.api.event.FoodRegistryInitEvent;
 import net.blay09.mods.cookingforblockheads.balyware.ItemUtils;
+import net.blay09.mods.cookingforblockheads.compat.HarvestCraftAddon;
 import net.blay09.mods.cookingforblockheads.container.inventory.InventoryCraftBook;
 import net.blay09.mods.cookingforblockheads.registry.recipe.FoodIngredient;
 import net.blay09.mods.cookingforblockheads.registry.recipe.FoodRecipe;
-import net.blay09.mods.cookingforblockheads.registry.recipe.*;
+import net.blay09.mods.cookingforblockheads.registry.recipe.ShapedCraftingFood;
+import net.blay09.mods.cookingforblockheads.registry.recipe.ShapedOreCraftingFood;
+import net.blay09.mods.cookingforblockheads.registry.recipe.ShapelessCraftingFood;
+import net.blay09.mods.cookingforblockheads.registry.recipe.ShapelessOreCraftingFood;
+import net.blay09.mods.cookingforblockheads.registry.recipe.SmeltingFood;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemFood;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.*;
+import net.minecraft.item.crafting.CraftingManager;
+import net.minecraft.item.crafting.FurnaceRecipes;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.ShapedRecipes;
+import net.minecraft.item.crafting.ShapelessRecipes;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
@@ -31,7 +41,10 @@ import net.minecraftforge.items.wrapper.InvWrapper;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
-import java.util.*;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
 
 public class CookingRegistry {
 
@@ -44,6 +57,7 @@ public class CookingRegistry {
     private static final Map<ItemStack, ToastHandler> toastHandlers = Maps.newHashMap();
     private static final List<ItemStack> waterItems = Lists.newArrayList();
     private static final List<ItemStack> milkItems = Lists.newArrayList();
+    private static final List<ICustomSortButton> customSortButtons = Lists.newArrayList();
 
     private static Collection<ItemStack> nonFoodRecipes;
 
@@ -292,6 +306,10 @@ public class CookingRegistry {
         milkItems.add(milkItem);
     }
 
+    public static void addCustomSortButton(ICustomSortButton button) {
+        customSortButtons.add(button);
+    }
+    
     public static List<ItemStack> getWaterItems() {
         return waterItems;
     }
@@ -300,6 +318,10 @@ public class CookingRegistry {
         return milkItems;
     }
 
+    public static List<ICustomSortButton> getCustomSortButtons() {
+        return customSortButtons;
+    }
+    
     public static boolean doesItemRequireBucketForCrafting(ItemStack outputItem) {
         ItemStack containerItem = ForgeHooks.getContainerItem(outputItem);
         if(containerItem != null && containerItem.getItem() == Items.BUCKET) {


### PR DESCRIPTION
Adds an addCustomSortButton method to add custom sorting buttons to the cookbook/cooking table GUI. Custom sort buttons expose an icon texture, a comparator, and a tooltip and are rendered below the existing sort buttons. The custom texture has the same layout as the existing buttons: three 20x20 buttons arranged vertically with enabled on top, hot in the middle, and disabled on the bottom.